### PR TITLE
Updated package.json to run dev port externally, updated webpack conf…

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "build": "tsc",
     "test": "mocha -c",
     "cover": "istanbul cover _mocha",
-    "start:dev": "webpack-dev-server --inline --content-base frontend/public --history-api-fallback",
+    "start:dev": "webpack-dev-server --port 8080 --host 0.0.0.0 --inline --content-base frontend/public --history-api-fallback",
     "start:prod": "webpack && node src/App.js"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,11 @@ module.exports = {
 
   output: {
     filename: 'bundle.js',
-    path: 'frontend/public',
+    path: 'frontend/public/',
     publicPath: ''
   },
+
+  watch: true,
 
   externals: {
     'config': JSON.stringify(require('./config.json'))


### PR DESCRIPTION
- Fixed hot reload error by adding flag in webpack config file. Frontend CSS changes update live after running `npm run start:dev`
- Updated npm package.json script to allow loading HTTP requests to come in externally through port 8080 and your IP while in development mode. (Others can view your dev environment through your IP).